### PR TITLE
Tmc intellij instructions

### DIFF
--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -20,7 +20,22 @@ Kun olet saanut opiskelijalisenssin käyttöösi, ladataan ja asennetaan Intelli
 
 # Windows
 
+1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=windows> ja paina Download-nappia Ultimate-tekstin alla.
+
+2. Lataa exe-tiedosto haluamaasi paikkaan. Tiedoston latauduttua asenna IntelliJ IDEA tuplaklikkaamalla ladattua tiedostoa.
+
+3. Intallation Setup Wizard aukeaa. Paina Next.
+
+4. Valitse paikka, mihin haluat ohjelmointiympäristön asennettavan. Paina Next.
+
+5. Valitse 64-bit launcher, mikäli sellainen vaihtoehto on näkyvillä. Jos ei, valitse 32-bit launcher. "Create assosiations" -kohdan voit jättää huomiotta. Paina Next.
+
+6. Valitse Start menu folder (oletuksena annettu Jetbrains on hyvä, ellet halua jotakin muuta). Valitse Install lopuksi.
+
+7. Kestää hetki kun IntelliJ asentuu. Sen asennuttua ruksita laatikko IntelliJ:n käynnistämisestä lopetettuasi, ja lopeta asennus painamalla "Finish"-nappia.
+
 Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
+
 
 # Linux
 

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -70,7 +70,7 @@ Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 
 # Seuraavaksi
 
-1. Ensimmäisen kerran IntelliJ:tä avattaessa, IntelliJ kysyy onko sinulla valmiita asetuksia jotka haluaisit importata ohjelmistoympäristöön. Valitse vaihtoehto "I do not have a previous version of IntelliJ IDEA or I do not want to import my settings" ja paina OK.
+1. Ensimmäisen kerran IntelliJ:tä avattaessa, IntelliJ kysyy onko sinulla valmiita asetuksia jotka haluaisit tuoda ohjelmistoympäristöön. Valitse vaihtoehto "I do not have a previous version of IntelliJ IDEA or I do not want to import my settings" ja paina OK.
 
 2. Tämän jälkeen sinulta kysytään lisenssiä. Avautuneessa ikkunassa oletuksena on "Activate license with Jetbrains Account", tämä on hyvä. Täytä lomake aiemmin tehdyn Jetbrains-tilin tiedoilla ja paina "Activate".
 

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -5,12 +5,20 @@ main-class: has-aside
 sidenav: general/ohjeita
 ---
 
-Jotta saisit IntelliJ IDEA:n Ultimate-version käyttöösi ilmaiseksi, sinun tarvitsee tehdä opiskelija-tili Jetbrainsille (yritykselle, joka kehittää ohjelmointiympäristöä).
+IntelliJ:stä on olemassa kaksi eri versiota - Ultimate ja Community. Community-versio on täysin ilmainen kaikille, ja sillä pystyy tekemään ainakin ohjelmoinnin
+perusteiden ja sen jatkokurssin tehtävät hyvin. Web-juttuja (esim. Web-palvelinohjelmoinnin kurssin tehtäviä) sillä ei kuitenkaan välttämättä pysty tekemään niin helposti.
 
-Mene osoitteeseen <https://www.jetbrains.com/shop/eform/students> ja täytä lomake tiedoillasi. Saat opiskelijalisenssin käyttöösi, kun käytät joko @helsinki.fi- 
-tai @cs.helsinki.fi-päätteistä sähköpostiosoitetta. Lomakkeen täytettyäsi saat ohjeet antamaasi sähköpostiosoitteeseen jatkotoimista opiskelijalisenssin saamisesta.
+Ultimate-versio pystyy myös tähän kuitenkin, ja se on suositeltu versio mikäli olet opiskelija. Opiskelijalisenssin saamiseksi sinun tarvitsee tehdä opiskelija-tili
+Jetbrainsille (yritykselle, joka kehittää kyseistä ohjelmointiympäristöä).
 
-Kun olet saanut opiskelijalisenssin käyttöösi, ladataan ja asennetaan IntelliJ IDEA -ohjelmistoympäristö. Ympäristön asentamisen alkutoimet tapahtuvat hieman eri tavalla eri käyttöjärjestelmillä. Valitse alta oma käyttöjärjestelmäsi:
+Mikäli et ole opiskelija, siirry asennusohjeisiin valitsemalla käyttöjärjestelmäsi alla olevasta valikosta.
+
+Jos olet opiskelija, tee opiskelija-tili Jetbrainsille menemällä osoitteeseen <https://www.jetbrains.com/shop/eform/students> ja täyttällä lomake tiedoillasi.
+Saat opiskelijalisenssin käyttöösi, kun käytät joko @helsinki.fi- tai @cs.helsinki.fi-päätteistä sähköpostiosoitetta. Myös muiden oppilaitosten sähköpostiosoitteiden
+pitäisi kelvata. Lomakkeen täytettyäsi saat ohjeet antamaasi sähköpostiosoitteeseen jatkotoimista opiskelijalisenssin saamisesta.
+
+Kun olet saanut opiskelijalisenssin käyttöösi (tai mikäli haluat käyttää Community-versiota), ladataan ja asennetaan IntelliJ IDEA -ohjelmistoympäristö. 
+Ympäristön asentamisen alkutoimet tapahtuvat hieman eri tavalla eri käyttöjärjestelmillä. Valitse alta oma käyttöjärjestelmäsi:
 
 <div class="actions">
 	<a class="action" href="#windows">Windows</a>
@@ -20,7 +28,7 @@ Kun olet saanut opiskelijalisenssin käyttöösi, ladataan ja asennetaan Intelli
 
 # Windows
 
-1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=windows> ja paina Download-nappia Ultimate-tekstin alla.
+1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=windows> ja paina Download-nappia haluamasi version alla (Community tai Ultimate).
 
 2. Lataa exe-tiedosto haluamaasi paikkaan. Tiedoston latauduttua asenna IntelliJ IDEA tuplaklikkaamalla ladattua tiedostoa.
 
@@ -39,7 +47,7 @@ Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 
 # Linux
 
-1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=linux> ja paina Download-nappia Ultimate-tekstin alla.
+1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=linux> ja paina Download-nappia haluamasi version alla (Community tai Ultimate).
 
 2. Talleta pakattu tar.gz-tiedosto haluaamasi paikkaan ja mene paikkaan johon sen latasit. Tiedoston ladauduttua pura (extract) tiedosto haluaamasi paikkaan.
 

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -5,6 +5,12 @@ main-class: has-aside
 sidenav: general/ohjeita
 ---
 
+Jos sinulla ei ole vielä JDK:ta (Java Development Kit) asennettuna koneellasi, asenna se ensimmäiseksi. Jos on, niin voit hypätä seuraavan linkin ohi.
+
+<div class="actions">
+	<a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/java">Javan asentaminen</a>
+</div>
+
 IntelliJ:stä on olemassa kaksi eri versiota - Ultimate ja Community. Community-versio on täysin ilmainen kaikille, ja sillä pystyy tekemään ainakin ohjelmoinnin
 perusteiden ja sen jatkokurssin tehtävät hyvin. Web-juttuja (esim. Web-palvelinohjelmoinnin kurssin tehtäviä) sillä ei kuitenkaan välttämättä pysty tekemään niin helposti.
 
@@ -62,7 +68,7 @@ Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 
 2. Talleta .dmg-hakemisto haluamaasi paikkaan.
 
-3. Avaa ladattu .dmg-hakemisto ja siirrä IDEA-app omaan Applications-hakemistoosi.
+3. Avaa ladattu .dmg-paketti ja siirrä IDEA-app omaan Applications-hakemistoosi.
 
 4. Aja ohjelma.
 

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -49,7 +49,7 @@ Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 - Anna näidenkin olla, ja paina vaan "Next: Featured plugins"
 - Tällä ruudulla asenna Scala, Live Edit Tool, Node.JS ja Angular. Jätä IdeaVim-liitännäinen asentamatta. Liitännäisten asennuttua paina "Start using IntelliJ IDEA".
 
-Asetusten jälkeen IntelliJ avaa Welcome-screenin. IntelliJ IDEA on nyt onnistuneesti assennettu, ja seuraavaksi asennamme TestMyCode-liitännäisen.
+Asetusten jälkeen IntelliJ avaa Welcome-screenin. IntelliJ IDEA on nyt onnistuneesti asennettu, ja seuraavaksi asennamme TestMyCode-liitännäisen.
 
 <div class="actions">
 	<a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/tmc/">TestMyCode -liitännäisen asentaminen</a>

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -1,0 +1,57 @@
+---
+title: Ympäristön asentaminen &ndash; IntelliJ IDEA
+layout: course
+main-class: has-aside
+sidenav: general/ohjeita
+---
+
+Jotta saisit IntelliJ IDEA:n Ultimate-version käyttöösi ilmaiseksi, sinun tarvitsee tehdä opiskelija-tili Jetbrainsille (yritykselle, joka kehittää ohjelmointiympäristöä).
+
+Mene osoitteeseen <https://www.jetbrains.com/shop/eform/students> ja täytä lomake tiedoillasi. Saat opiskelijalisenssin käyttöösi, kun käytät joko @helsinki.fi- 
+tai @cs.helsinki.fi-päätteistä sähköpostiosoitetta. Lomakkeen täytettyäsi saat ohjeet antamaasi sähköpostiosoitteeseen jatkotoimista opiskelijalisenssin saamisesta.
+
+Kun olet saanut opiskelijalisenssin käyttöösi, ladataan ja asennetaan IntelliJ IDEA -ohjelmistoympäristö. Ympäristön asentamisen alkutoimet tapahtuvat hieman eri tavalla eri käyttöjärjestelmillä. Valitse alta oma käyttöjärjestelmäsi:
+
+<div class="actions">
+	<a class="action" href="#windows">Windows</a>
+	<a class="action" href="#mac-os-x">Max OS X</a>
+	<a class="action" href="#linux">Linux</a>
+</div>
+
+# Windows
+
+Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
+
+# Linux
+
+1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=linux> ja paina Download-nappia Ultimate-tekstin alla.
+
+2. Talleta pakattu tar.gz-tiedosto haluaamasi paikkaan ja mene paikkaan johon sen latasit. Tiedoston ladauduttua pura (extract) tiedosto haluaamasi paikkaan.
+
+3. Avaa komentorivi, siirry puretun kansion sisälle (cd-komennolla, esim. cd idea-IU-162.1628.40, mikäli purit tiedoston Home-hakemistosi juureen), ja siellä bin-kansioon ja kirjoita ./idea.sh
+
+Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
+
+# Mac OS X
+
+Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
+
+# Seuraavaksi
+
+1. Ensimmäisen kerran IntelliJ:tä avattaessa, IntelliJ kysyy onko sinulla valmiita asetuksia jotka haluaisit importata ohjelmistoympäristöön. Valitse vaihtoehto "I do not have a previous version of IntelliJ IDEA or I do not want to import my settings" ja paina OK.
+
+2. Tämän jälkeen sinulta kysytään lisenssiä. Avautuneessa ikkunassa oletuksena on "Activate license with Jetbrains Account", tämä on hyvä. Täytä lomake aiemmin tehdyn Jetbrains-tilin tiedoilla ja paina "Activate".
+
+3. Tämän jälkeen IntelliJ kysyy sekalaisia kysymyksiä asetuksiin liittyen. Älä skippaa näitä. 
+- Ensimmäisen kohdalla voit valita teeman (IntelliJ on hyvä, mutta tumman teeman halutessasi valitse Darcula (tätä voi muuttaa myöhemmin). Paina "Next: Desktop Entry". 
+- Seuraavalla ruudulla anna oletuksen olla (ellei koneellasi ole useampi ihminen joka käyttäisi ohjelmistoympäristöä) ja paina "Next: Launcher Script". 
+- Tälläkin ruudulla paina vaan "Next: Default plugins". 
+- Anna näidenkin olla, ja paina vaan "Next: Featured plugins"
+- Tällä ruudulla asenna Scala, Live Edit Tool, Node.JS ja Angular. Jätä IdeaVim-liitännäinen asentamatta. Liitännäisten asennuttua paina "Start using IntelliJ IDEA".
+
+Asetusten jälkeen IntelliJ avaa Welcome-screenin. IntelliJ IDEA on nyt onnistuneesti assennettu, ja seuraavaksi asennamme TestMyCode-liitännäisen.
+
+<div class="actions">
+	<a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/tmc/">TestMyCode -liitännäisen asentaminen</a>
+</div>
+

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -30,7 +30,7 @@ Ympäristön asentamisen alkutoimet tapahtuvat hieman eri tavalla eri käyttöj�
 
 1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=windows> ja paina Download-nappia haluamasi version alla (Community tai Ultimate).
 
-2. Lataa exe-tiedosto haluamaasi paikkaan. Tiedoston latauduttua asenna IntelliJ IDEA tuplaklikkaamalla ladattua tiedostoa.
+2. Lataa exe-tiedosto haluamaasi paikkaan. Tiedoston latauduttua asenna IntelliJ IDEA ajamalla tiedosto.
 
 3. Intallation Setup Wizard aukeaa. Paina Next.
 
@@ -49,13 +49,22 @@ Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 
 1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=linux> ja paina Download-nappia haluamasi version alla (Community tai Ultimate).
 
-2. Talleta pakattu tar.gz-tiedosto haluaamasi paikkaan ja mene paikkaan johon sen latasit. Tiedoston ladauduttua pura (extract) tiedosto haluaamasi paikkaan.
+2. Talleta pakattu tar.gz-tiedosto haluaamasi paikkaan ja siirry paikkaan johon sen latasit. Tiedoston latauduttua pura (extract) tiedosto haluaamasi paikkaan.
 
-3. Avaa komentorivi, siirry puretun kansion sisälle (cd-komennolla, esim. cd idea-IU-162.1628.40, mikäli purit tiedoston Home-hakemistosi juureen), ja siellä bin-kansioon ja kirjoita ./idea.sh
+3. Avaa komentorivi, siirry puretun kansion sisälle (cd-komennolla, esim. cd idea-IU-162.1628.40, mikäli purit tiedoston Home-hakemistosi juureen),
+ja siellä bin-kansioon ja kirjoita ./idea.sh
 
 Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 
 # Mac OS X
+
+1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=mac> ja paina Download-nappia haluamasi version alla (Community tai Ultimate).
+
+2. Talleta .dmg-hakemisto haluamaasi paikkaan.
+
+3. Avaa ladattu .dmg-hakemisto ja siirrä IDEA-app omaan Applications-hakemistoosi.
+
+4. Aja ohjelma.
 
 Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -8,7 +8,7 @@ sidenav: general/ohjeita
 Jos sinulla ei ole vielä JDK:ta (Java Development Kit) asennettuna koneellasi, asenna se ensimmäiseksi. Jos on, niin voit hypätä seuraavan linkin ohi.
 
 <div class="actions">
-	<a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/java">Javan asentaminen</a>
+    <a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/java">Javan asentaminen</a>
 </div>
 
 IntelliJ:stä on olemassa kaksi eri versiota - Ultimate ja Community. Community-versio on täysin ilmainen kaikille, ja sillä pystyy tekemään ainakin ohjelmoinnin
@@ -27,9 +27,9 @@ Kun olet saanut opiskelijalisenssin käyttöösi (tai mikäli haluat käyttää 
 Ympäristön asentamisen alkutoimet tapahtuvat hieman eri tavalla eri käyttöjärjestelmillä. Valitse alta oma käyttöjärjestelmäsi:
 
 <div class="actions">
-	<a class="action" href="#windows">Windows</a>
-	<a class="action" href="#mac-os-x">Max OS X</a>
-	<a class="action" href="#linux">Linux</a>
+    <a class="action" href="#windows">Windows</a>
+    <a class="action" href="#mac-os-x">Max OS X</a>
+    <a class="action" href="#linux">Linux</a>
 </div>
 
 # Windows
@@ -90,6 +90,6 @@ Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 Asetusten jälkeen IntelliJ avaa Welcome-screenin. IntelliJ IDEA on nyt onnistuneesti asennettu, ja seuraavaksi asennamme TestMyCode-liitännäisen.
 
 <div class="actions">
-	<a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/tmc/">TestMyCode -liitännäisen asentaminen</a>
+    <a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/tmc/">TestMyCode -liitännäisen asentaminen</a>
 </div>
 

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -15,7 +15,7 @@ Mikäli et ole opiskelija, siirry asennusohjeisiin valitsemalla käyttöjärjest
 
 Jos olet opiskelija, tee opiskelija-tili Jetbrainsille menemällä osoitteeseen <https://www.jetbrains.com/shop/eform/students> ja täyttällä lomake tiedoillasi.
 Saat opiskelijalisenssin käyttöösi, kun käytät joko @helsinki.fi- tai @cs.helsinki.fi-päätteistä sähköpostiosoitetta. Myös muiden oppilaitosten sähköpostiosoitteiden
-pitäisi kelvata. Lomakkeen täytettyäsi saat ohjeet antamaasi sähköpostiosoitteeseen jatkotoimista opiskelijalisenssin saamisesta.
+pitäisi kelvata. Lomakkeen täytettyäsi saat ohjeet antamaasi sähköpostiosoitteeseen jatkotoimista opiskelijalisenssin saamiseksi.
 
 Kun olet saanut opiskelijalisenssin käyttöösi (tai mikäli haluat käyttää Community-versiota), ladataan ja asennetaan IntelliJ IDEA -ohjelmistoympäristö. 
 Ympäristön asentamisen alkutoimet tapahtuvat hieman eri tavalla eri käyttöjärjestelmillä. Valitse alta oma käyttöjärjestelmäsi:

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -23,7 +23,7 @@ Jos olet opiskelija, tee opiskelija-tili Jetbrainsille menemällä osoitteeseen 
 Saat opiskelijalisenssin käyttöösi, kun käytät joko @helsinki.fi- tai @cs.helsinki.fi-päätteistä sähköpostiosoitetta. Myös muiden oppilaitosten sähköpostiosoitteiden
 pitäisi kelvata. Lomakkeen täytettyäsi saat ohjeet antamaasi sähköpostiosoitteeseen jatkotoimista opiskelijalisenssin saamiseksi.
 
-Kun olet saanut opiskelijalisenssin käyttöösi (tai mikäli haluat käyttää Community-versiota), ladataan ja asennetaan IntelliJ IDEA -ohjelmistoympäristö. 
+Kun olet saanut opiskelijalisenssin käyttöösi (tai mikäli haluat käyttää Community-versiota), ladataan ja asennetaan IntelliJ IDEA -ohjelmistoympäristö.
 Ympäristön asentamisen alkutoimet tapahtuvat hieman eri tavalla eri käyttöjärjestelmillä. Valitse alta oma käyttöjärjestelmäsi:
 
 <div class="actions">
@@ -78,12 +78,12 @@ Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 
 1. Ensimmäisen kerran IntelliJ:tä avattaessa, IntelliJ kysyy onko sinulla valmiita asetuksia jotka haluaisit tuoda ohjelmistoympäristöön. Valitse vaihtoehto "I do not have a previous version of IntelliJ IDEA or I do not want to import my settings" ja paina OK.
 
-2. Tämän jälkeen sinulta kysytään lisenssiä. Avautuneessa ikkunassa oletuksena on "Activate license with Jetbrains Account", tämä on hyvä. Täytä lomake aiemmin tehdyn Jetbrains-tilin tiedoilla ja paina "Activate".
+2. **Jos** asensit Ultimate-version, tässä vaiheessa sinulta kysytään lisenssiä. Avautuneessa ikkunassa oletuksena on "Activate license with Jetbrains Account", tämä on hyvä. Täytä lomake aiemmin tehdyn Jetbrains-tilin tiedoilla ja paina "Activate".
 
-3. Tämän jälkeen IntelliJ kysyy sekalaisia kysymyksiä asetuksiin liittyen. Älä skippaa näitä. 
-- Ensimmäisen kohdalla voit valita teeman (IntelliJ on hyvä, mutta tumman teeman halutessasi valitse Darcula (tätä voi muuttaa myöhemmin). Paina "Next: Desktop Entry". 
-- Seuraavalla ruudulla anna oletuksen olla (ellei koneellasi ole useampi ihminen joka käyttäisi ohjelmistoympäristöä) ja paina "Next: Launcher Script". 
-- Tälläkin ruudulla paina vaan "Next: Default plugins". 
+3. Tämän jälkeen IntelliJ kysyy sekalaisia kysymyksiä asetuksiin liittyen. Älä skippaa näitä.
+- Ensimmäisen kohdalla voit valita teeman (IntelliJ on hyvä, mutta tumman teeman halutessasi valitse Darcula (tätä voi muuttaa myöhemmin). Paina "Next: Desktop Entry".
+- Seuraavalla ruudulla anna oletuksen olla (ellei koneellasi ole useampi ihminen joka käyttäisi ohjelmistoympäristöä) ja paina "Next: Launcher Script".
+- Tälläkin ruudulla paina vaan "Next: Default plugins".
 - Anna näidenkin olla, ja paina vaan "Next: Featured plugins"
 - Tällä ruudulla asenna Scala, Live Edit Tool, Node.JS ja Angular. Jätä IdeaVim-liitännäinen asentamatta. Liitännäisten asennuttua paina "Start using IntelliJ IDEA".
 
@@ -92,4 +92,3 @@ Asetusten jälkeen IntelliJ avaa Welcome-screenin. IntelliJ IDEA on nyt onnistun
 <div class="actions">
     <a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/tmc/">TestMyCode -liitännäisen asentaminen</a>
 </div>
-

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -32,7 +32,7 @@ Ympäristön asentamisen alkutoimet tapahtuvat hieman eri tavalla eri käyttöj�
 
 2. Lataa exe-tiedosto haluamaasi paikkaan. Tiedoston latauduttua asenna IntelliJ IDEA ajamalla tiedosto.
 
-3. Intallation Setup Wizard aukeaa. Paina Next.
+3. Installation Setup Wizard aukeaa. Paina Next.
 
 4. Valitse paikka, mihin haluat ohjelmointiympäristön asennettavan. Paina Next.
 

--- a/courses/general/ohjelmointi/asentaminen/intellij/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/index.md
@@ -49,7 +49,7 @@ Tässä vaiheessa voit siirtyä [seuraavaan vaiheeseen](#seuraavaksi).
 
 1. Mene osoitteeseen <https://www.jetbrains.com/idea/download/#section=linux> ja paina Download-nappia haluamasi version alla (Community tai Ultimate).
 
-2. Talleta pakattu tar.gz-tiedosto haluaamasi paikkaan ja siirry paikkaan johon sen latasit. Tiedoston latauduttua pura (extract) tiedosto haluaamasi paikkaan.
+2. Talleta pakattu tar.gz-tiedosto haluamasi paikkaan ja siirry paikkaan johon sen latasit. Tiedoston latauduttua pura (extract) tiedosto haluaamasi paikkaan.
 
 3. Avaa komentorivi, siirry puretun kansion sisälle (cd-komennolla, esim. cd idea-IU-162.1628.40, mikäli purit tiedoston Home-hakemistosi juureen),
 ja siellä bin-kansioon ja kirjoita ./idea.sh

--- a/courses/general/ohjelmointi/asentaminen/intellij/java/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/java/index.md
@@ -24,5 +24,5 @@ käyttöjärjestelmällesi x86-versio.
 Voit nyt siirtyä takaisin IntelliJ:n asentamiseen.
 
 <div class="actions">
-	<a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/">IntelliJ IDEA:n asentaminen</a>
+    <a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/">IntelliJ IDEA:n asentaminen</a>
 </div>

--- a/courses/general/ohjelmointi/asentaminen/intellij/java/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/java/index.md
@@ -1,0 +1,28 @@
+---
+title: Ympäristön asentaminen &ndash; Java
+layout: course
+main-class: has-aside
+sidenav: general/ohjeita
+---
+
+Tämä ohje on IntelliJ IDEAn asennusta varten, sillä siinä ei tule JDK:ta (Java Development Kit) mukana. 
+Jos olet asentamassa Netbeansiä, tai jos sinulla on jo koneellasi JDK, jätä tämä huomiotta.
+
+1. Mene osoitteeseen <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>
+
+2. Valitse uusin versio, ja hyväksy lisenssi.
+
+3. Valitse käyttöjärjestelmällesi sopiva versio ja asenna se.
+
+- Jos käytät Windowsia tai Linuxia, etkä ole varma onko koneesi 32- vai 64-bittinen, valitse
+käyttöjärjestelmällesi x86-versio.
+- Jos käytät Linuxia, valitse .tar.gz-päätteinen pakattu tiedosto
+  - Pura tiedosto haluamaasi paikkaan
+- Jos käytät Maccia, asennus tapahtuu samalla tavoin kuin minkä tahansa .dmg-paketin asennus
+- Windowsissa asennus myös tapahtuu samalla tavoin kuin minkä tahansa Windows-ohjelman asennus (aja ladattu .exe-tiedosto)
+
+Voit nyt siirtyä takaisin IntelliJ:n asentamiseen.
+
+<div class="actions">
+	<a class="action" href="/courses/general/ohjelmointi/asentaminen/intellij/">IntelliJ IDEA:n asentaminen</a>
+</div>

--- a/courses/general/ohjelmointi/asentaminen/intellij/tmc/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/tmc/index.md
@@ -22,8 +22,6 @@ Mikäli et ole tehnyt aiemmin yhtäkään projektia IntelliJ:llä, IntelliJ avaa
 
 # Seuraavaksi
 
-# Seuraavaksi
-
 Onnistuneen asennuksen jälkeen, siirry luomaan itsellesi käyttäjätunnusta TestMyCode -tarkistusjärjestelmäämme. 
 
 Mikäli olet jo aiemmin luonut käyttäjätunnuksen esimerkiksi jotain toista kurssiamme varten, voit käyttää sitä ja siirtyä takaisin kurssille.

--- a/courses/general/ohjelmointi/asentaminen/intellij/tmc/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/tmc/index.md
@@ -1,0 +1,102 @@
+# tmc asennusohjeet Intellij:tä varten tähän
+
+---
+title: Ympäristön asentaminen &ndash; TMC
+layout: course
+main-class: has-aside
+sidenav: general/ohjeita
+---
+Jotta tehtävien palauttaminen onnistuisi, on IntelliJ:hin asennettava TMC-liitännäinen.
+
+Käynnistä IntelliJ IDEA -ohjelmointiympäristö.
+
+Mikäli et ole tehnyt aiemmin yhtäkään projektia IntelliJ:llä, IntelliJ avaa Welcome screenin. Aloitetaan TMC-liitännäisen asennus.
+
+1. Valitse alapalkista Configure / Plugins.
+
+2. Paina Browser Repositories-nappia alhaalla.
+
+3. Kirjoita hakukenttään TMC, ja tulokseksi pitäisi tulla TMC Plugin for IntelliJ.
+
+4. Valitse Install. Anna pluginin latautua (siinä ei pitäisi kestää kauaa).
+
+5. Valitse Restart IntelliJ IDEA käynnistääksesi IntelliJ:n uudestaan.
+
+# Seuraavaksi
+
+# Seuraavaksi
+
+Onnistuneen asennuksen jälkeen, siirry luomaan itsellesi käyttäjätunnusta TestMyCode -tarkistusjärjestelmäämme. 
+
+Mikäli olet jo aiemmin luonut käyttäjätunnuksen esimerkiksi jotain toista kurssiamme varten, voit käyttää sitä ja siirtyä takaisin kurssille.
+
+<div class="actions">
+    <a class="action" href="/courses/general/ohjelmointi/rekisteroityminen/">Siirry luomaan tunnuksia</a>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+###### (tmc-netbeansin ohjeet tässä):: --------------------------------------
+---
+title: Ympäristön asentaminen &ndash; TMC
+layout: course
+main-class: has-aside
+sidenav: general/ohjeita
+---
+Jotta tehtävien palauttaminen onnistuisi, on NetBeansiin asennettava TMC-liitännäinen.
+
+Käynnistä NetBeans-ohjelmointiympäristö.
+
+NetBeans koostuu useammasta ikkunasta. Vasemmalla laidalla on projektivalikko, sekä välilehdet tiedostoille (projektiin liittyvät ei-projektinäkymässä näkyvät tiedostot, esimerkiksi testidata ym.) ja palveluille (esim. tietokantayhteydet ja palvelimet). Tällä hetkellä meillä ei ole yhtään käytössä olevaa projektia. Alalaidassa on tulostusalue.
+
+Keskellä olevassa ikkunassa saattaa olla linkkejä erilaisiin blogeihin ja web-posteihin. Voit sulkea kyseisen ikkunan halutessasi.
+
+Aloitetaan TMC-liitännäisen asennus. 
+
+1. Valitse yläpalkista Tools / Plugins.
+  ![NetBeans Tools->Plugins]({{"/img/install/plugin-install/plugin-2.png" | prepend: site.baseurl}})
+2. Eteesi aukeaa plugins-ikkuna. Valitse ikkunasta välilehti Settings ja klikkaa Add.
+  ![NetBeans Plugins Settings->Add]({{"/img/install/plugin-install/plugin-5.png" | prepend: site.baseurl}})
+3. Eteesi aukeaa ikkuna, johon sinun tulee täyttää liitännäisen lähdetiedot.
+    ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-6.png" | prepend: site.baseurl}})
+    
+    3.1. Kirjoita kenttään *Name* esimerkiksi "TMC".
+
+    3.2. Kopioi URL-kenttään teksti: <http://update.testmycode.net/tmc-netbeans_mooc/updates.xml>
+
+4. Pääset takaisin plugins-ikkunaan. Valitse ikkunasta välilehti Available Plugins, ja kirjoita Search-kenttään TMC.
+    
+    ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-10.png" | prepend: site.baseurl}})
+    
+    4.1. Klikkaa ruksi valituksi ja paina install
+        ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-12.png" | prepend: site.baseurl}})
+        ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-13.png" | prepend: site.baseurl}})
+5. Hyväksy lisenssiehdot asennuksen aikana
+
+    ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-15.png" | prepend: site.baseurl}})
+
+    Asennusvaiheessa saatat törmätä seuraavaan ilmoitukseen, jatka asentamista painamalla "Continue".
+
+    ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-16.png" | prepend: site.baseurl}})
+
+9. Kun asennus on valmis käynnistä NetBeans uudelleen
+
+	![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-17.png" | prepend: site.baseurl}})
+
+# Seuraavaksi
+
+Onnistuneen asennuksen jälkeen, siirry luomaan itsellesi käyttäjätunnusta TestMyCode -tarkistusjärjestelmäämme. 
+
+Mikäli olet jo aiemmin luonut käyttäjätunnuksen esimerkiksi jotain toista kurssiamme varten, voit käyttää sitä ja siirtyä takaisin kurssille.
+
+<div class="actions">
+    <a class="action" href="/courses/general/ohjelmointi/rekisteroityminen/">Siirry luomaan tunnuksia</a>
+</div>

--- a/courses/general/ohjelmointi/asentaminen/intellij/tmc/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/tmc/index.md
@@ -1,5 +1,3 @@
-# tmc asennusohjeet Intellij:tä varten tähän
-
 ---
 title: Ympäristön asentaminen &ndash; TMC
 layout: course
@@ -23,73 +21,6 @@ Mikäli et ole tehnyt aiemmin yhtäkään projektia IntelliJ:llä, IntelliJ avaa
 5. Valitse Restart IntelliJ IDEA käynnistääksesi IntelliJ:n uudestaan.
 
 # Seuraavaksi
-
-# Seuraavaksi
-
-Onnistuneen asennuksen jälkeen, siirry luomaan itsellesi käyttäjätunnusta TestMyCode -tarkistusjärjestelmäämme. 
-
-Mikäli olet jo aiemmin luonut käyttäjätunnuksen esimerkiksi jotain toista kurssiamme varten, voit käyttää sitä ja siirtyä takaisin kurssille.
-
-<div class="actions">
-    <a class="action" href="/courses/general/ohjelmointi/rekisteroityminen/">Siirry luomaan tunnuksia</a>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-###### (tmc-netbeansin ohjeet tässä):: --------------------------------------
----
-title: Ympäristön asentaminen &ndash; TMC
-layout: course
-main-class: has-aside
-sidenav: general/ohjeita
----
-Jotta tehtävien palauttaminen onnistuisi, on NetBeansiin asennettava TMC-liitännäinen.
-
-Käynnistä NetBeans-ohjelmointiympäristö.
-
-NetBeans koostuu useammasta ikkunasta. Vasemmalla laidalla on projektivalikko, sekä välilehdet tiedostoille (projektiin liittyvät ei-projektinäkymässä näkyvät tiedostot, esimerkiksi testidata ym.) ja palveluille (esim. tietokantayhteydet ja palvelimet). Tällä hetkellä meillä ei ole yhtään käytössä olevaa projektia. Alalaidassa on tulostusalue.
-
-Keskellä olevassa ikkunassa saattaa olla linkkejä erilaisiin blogeihin ja web-posteihin. Voit sulkea kyseisen ikkunan halutessasi.
-
-Aloitetaan TMC-liitännäisen asennus. 
-
-1. Valitse yläpalkista Tools / Plugins.
-  ![NetBeans Tools->Plugins]({{"/img/install/plugin-install/plugin-2.png" | prepend: site.baseurl}})
-2. Eteesi aukeaa plugins-ikkuna. Valitse ikkunasta välilehti Settings ja klikkaa Add.
-  ![NetBeans Plugins Settings->Add]({{"/img/install/plugin-install/plugin-5.png" | prepend: site.baseurl}})
-3. Eteesi aukeaa ikkuna, johon sinun tulee täyttää liitännäisen lähdetiedot.
-    ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-6.png" | prepend: site.baseurl}})
-    
-    3.1. Kirjoita kenttään *Name* esimerkiksi "TMC".
-
-    3.2. Kopioi URL-kenttään teksti: <http://update.testmycode.net/tmc-netbeans_mooc/updates.xml>
-
-4. Pääset takaisin plugins-ikkunaan. Valitse ikkunasta välilehti Available Plugins, ja kirjoita Search-kenttään TMC.
-    
-    ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-10.png" | prepend: site.baseurl}})
-    
-    4.1. Klikkaa ruksi valituksi ja paina install
-        ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-12.png" | prepend: site.baseurl}})
-        ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-13.png" | prepend: site.baseurl}})
-5. Hyväksy lisenssiehdot asennuksen aikana
-
-    ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-15.png" | prepend: site.baseurl}})
-
-    Asennusvaiheessa saatat törmätä seuraavaan ilmoitukseen, jatka asentamista painamalla "Continue".
-
-    ![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-16.png" | prepend: site.baseurl}})
-
-9. Kun asennus on valmis käynnistä NetBeans uudelleen
-
-	![NetBeans Plugins Source]({{"/img/install/plugin-install/plugin-17.png" | prepend: site.baseurl}})
 
 # Seuraavaksi
 

--- a/courses/general/ohjelmointi/asentaminen/intellij/tmc/index.md
+++ b/courses/general/ohjelmointi/asentaminen/intellij/tmc/index.md
@@ -12,7 +12,7 @@ Mikäli et ole tehnyt aiemmin yhtäkään projektia IntelliJ:llä, IntelliJ avaa
 
 1. Valitse alapalkista Configure / Plugins.
 
-2. Paina Browser Repositories-nappia alhaalla.
+2. Paina Browse Repositories-nappia alhaalla.
 
 3. Kirjoita hakukenttään TMC, ja tulokseksi pitäisi tulla TMC Plugin for IntelliJ.
 
@@ -22,7 +22,7 @@ Mikäli et ole tehnyt aiemmin yhtäkään projektia IntelliJ:llä, IntelliJ avaa
 
 # Seuraavaksi
 
-Onnistuneen asennuksen jälkeen, siirry luomaan itsellesi käyttäjätunnusta TestMyCode -tarkistusjärjestelmäämme. 
+Onnistuneen asennuksen jälkeen, siirry luomaan itsellesi käyttäjätunnusta TestMyCode-tarkistusjärjestelmäämme.
 
 Mikäli olet jo aiemmin luonut käyttäjätunnuksen esimerkiksi jotain toista kurssiamme varten, voit käyttää sitä ja siirtyä takaisin kurssille.
 

--- a/courses/general/ohjelmointi/tehtavien-tekeminen-ja-palauttaminen/index.md
+++ b/courses/general/ohjelmointi/tehtavien-tekeminen-ja-palauttaminen/index.md
@@ -5,9 +5,9 @@ main-class: has-aside
 sidenav: general/ohjeita
 ---
 
-Mikäli käytät Netbeansia, ensimmäistä kertaa TMC-liitännäisen sisältävän Netbeansin käynnistäessä TMC:n asetusnäkymän pitäisi aueta automaattisesti. Mikäli näin ei kuitenkaan tapahdu, valitse NetBeansin valikosta TMC \| Settings.
+Mikäli käytät **Netbeansia**, ensimmäistä kertaa TMC-liitännäisen sisältävän Netbeansin käynnistäessä TMC:n asetusnäkymän pitäisi aueta automaattisesti. Mikäli näin ei kuitenkaan tapahdu, valitse NetBeansin valikosta TMC \| Settings.
 
-Jos käytät IntelliJ:tä, käynnistäessä kyseistä ohjelmistoympäristöä ensimmäistä kertaa TMC-liitännäisen kanssa, sinun täytyy valita *Get started with TMC* -vaihtoehto.
+Jos käytät **IntelliJ:tä**, käynnistäessä kyseistä ohjelmistoympäristöä ensimmäistä kertaa TMC-liitännäisen kanssa, sinun täytyy valita *Get started with TMC* -vaihtoehto.
 
 1. Syötä TMC-palvelimelle rekisteröimäsi käyttäjätunnus kenttään *Username*
 2. Syötä käyttäjätunnusta vastaava salasana kenttään *Password*

--- a/courses/general/ohjelmointi/tehtavien-tekeminen-ja-palauttaminen/index.md
+++ b/courses/general/ohjelmointi/tehtavien-tekeminen-ja-palauttaminen/index.md
@@ -4,7 +4,10 @@ layout: course
 main-class: has-aside
 sidenav: general/ohjeita
 ---
-Kun käynnistät TMC-liitännäisen sisältävän NetBeansin ensimmäistä kertaa, pitäisi TMC:n asetusnäkymän aueta automaattisesti. Mikäli näin ei kuitenkaan tapahdu, valitse NetBeansin valikosta TMC \| Settings.
+
+Mikäli käytät Netbeansia, ensimmäistä kertaa TMC-liitännäisen sisältävän Netbeansin käynnistäessä TMC:n asetusnäkymän pitäisi aueta automaattisesti. Mikäli näin ei kuitenkaan tapahdu, valitse NetBeansin valikosta TMC \| Settings.
+
+Jos käytät IntelliJ:tä, käynnistäessä kyseistä ohjelmistoympäristöä ensimmäistä kertaa TMC-liitännäisen kanssa, sinun täytyy valita *Get started with TMC* -vaihtoehto.
 
 1. Syötä TMC-palvelimelle rekisteröimäsi käyttäjätunnus kenttään *Username*
 2. Syötä käyttäjätunnusta vastaava salasana kenttään *Password*
@@ -14,9 +17,9 @@ Kun käynnistät TMC-liitännäisen sisältävän NetBeansin ensimmäistä kerta
 5. Valitse suoritettava kurssi *Current course* -pudotusvalikosta. 
 	- Mikäli suoritat kevään 2016 ohjelmoinnin MOOC -kurssia, valitse **2016-ohjelmointi** tai **2016-nodl-ohjelmointi**.
 	- Mikäli suoritat jotain muuta kurssia, katso kurssisi tunnus kurssin sivuilta
-6. Olet nyt valmis ja voit aloittaa tehtävien tekemisen painamalla *OK*
+6. Olet nyt valmis ja Netbeansissä voit aloittaa tehtävien tekemisen painamalla *OK*. IntelliJ:ssä paina *Download course exercises*.
 
-Seuraavalla videolla näytetään miten tehtävien tekeminen ja palauttaminen NetBeansilla ja TMC:llä tapahtuu.
+Seuraavalla videolla näytetään miten tehtävien tekeminen ja palauttaminen NetBeansilla ja TMC:llä tapahtuu. IntelliJ:tä käyttäessä prosessi on pitkälti samanlainen.
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/sQYq2LISMRU" frameborder="0" allowfullscreen></iframe>
 

--- a/courses/general/ohjelmointi/tehtavien-tekeminen-ja-palauttaminen/index.md
+++ b/courses/general/ohjelmointi/tehtavien-tekeminen-ja-palauttaminen/index.md
@@ -5,9 +5,13 @@ main-class: has-aside
 sidenav: general/ohjeita
 ---
 
+Ohjelmistoympäristön aloittaminen menee hieman eri tavalla riippuen ohjelmistoympäristöstäsi.
+
 Mikäli käytät **Netbeansia**, ensimmäistä kertaa TMC-liitännäisen sisältävän Netbeansin käynnistäessä TMC:n asetusnäkymän pitäisi aueta automaattisesti. Mikäli näin ei kuitenkaan tapahdu, valitse NetBeansin valikosta TMC \| Settings.
 
 Jos käytät **IntelliJ:tä**, käynnistäessä kyseistä ohjelmistoympäristöä ensimmäistä kertaa TMC-liitännäisen kanssa, sinun täytyy valita *Get started with TMC* -vaihtoehto.
+
+Seuraavat kohdat menevät samalla tavalla:
 
 1. Syötä TMC-palvelimelle rekisteröimäsi käyttäjätunnus kenttään *Username*
 2. Syötä käyttäjätunnusta vastaava salasana kenttään *Password*

--- a/courses/general/ohjelmointi/tehtavien-tekeminen-ja-palauttaminen/index.md
+++ b/courses/general/ohjelmointi/tehtavien-tekeminen-ja-palauttaminen/index.md
@@ -23,7 +23,9 @@ Seuraavat kohdat menevät samalla tavalla:
 	- Mikäli suoritat jotain muuta kurssia, katso kurssisi tunnus kurssin sivuilta
 6. Olet nyt valmis ja Netbeansissä voit aloittaa tehtävien tekemisen painamalla *OK*. IntelliJ:ssä paina *Download course exercises*.
 
-Seuraavalla videolla näytetään miten tehtävien tekeminen ja palauttaminen NetBeansilla ja TMC:llä tapahtuu. IntelliJ:tä käyttäessä prosessi on pitkälti samanlainen.
+Seuraavalla videolla näytetään miten tehtävien tekeminen ja palauttaminen NetBeansilla ja TMC:llä tapahtuu. IntelliJ:tä käyttäessä prosessi on pitkälti samanlainen,
+mutta **HUOM.** ensimmäistä tehtävää tehdessäsi joudut asettamaan IntelliJ:lle aiemmin asentamasi JDK:n. IntelliJ:n pitäisi pyytää sinua
+suoraan antamaan se, mutta jos ei, niin voit asettaa sen avaamalla File / Project Structure -ikkunan, ja asettamalla sen kohdassa "Project SDK".
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/sQYq2LISMRU" frameborder="0" allowfullscreen></iframe>
 

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -68,7 +68,7 @@ Download button.
 Then, download the the TestMyCode plugin. 
 
 When IntelliJ opens for the first time, you get to a welcome screen. At the bottom, choose Configure / Plugins. At the bottom of the window that opens,
-choose "Browser repositores" and type something like "TMC" to the search field. Install the plugin and restart IntelliJ.
+choose "Browse repositories" and type something like "TMC" to the search field. Install the plugin and restart IntelliJ.
 
 
 # Completing and submitting the programming assignments with Netbeans

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -78,8 +78,6 @@ using **IntelliJ**, you get to a Welcome screen, in which you can press the "Get
 
 ![tmc-settings]({{ "/img/programming/tmc-settings.png" | prepend: site.baseurl }})
 
-Now move on to the next phase
-
 Give the Username and Password that you gave during registration.
 
 Press the button "refresh list" and select course from "Current course".

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -84,8 +84,8 @@ Press the button "refresh list" and select course from "Current course".
 
 By pressing "ok" the assignment "projects" are downloaded to your computer.
 
-The next video shows how to program and submit the assignments using TMC/NetBeans. The process is mostly the same in IntelliJ, except, **important**,
-for the first time you open up an exercise, you need to set the JDK that you installed earlier. IntelliJ should ask you give it, but if not,
+The next video shows how to program and submit the assignments using TMC/NetBeans. The process is mostly the same in IntelliJ, however, there's
+one **important** thing: For the first time you open up an exercise, you need to set the JDK that you installed earlier. IntelliJ should ask you give it, but if not,
 you can set it from File / Project Structure at "Project SDK" part.
 
 <iframe width="560" height="315" src="//www.youtube.com/embed/ZFsg0Uh0UVE" frameborder="0" allowfullscreen></iframe>

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -65,7 +65,7 @@ Download button.
       - The script can be executed only if it has been given right permissions eg. with command `chmod +x bin/idea.sh`.
       - In Ubuntu, for example, the execution permissions can be given using the File browser  by right clicking the script and selecting Properties / Permissions / Allow executing file as program. After doing this, the script can be executed by clicking it.
 
-Then, download the the TestMyCode plugin. 
+Then, download the the TestMyCode plugin:
 
 When IntelliJ opens for the first time, you get to a welcome screen. At the bottom, choose Configure / Plugins. At the bottom of the window that opens,
 choose "Browse repositories" and type something like "TMC" to the search field. Install the plugin and restart IntelliJ.

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -86,7 +86,7 @@ Press the button "refresh list" and select course from "Current course".
 
 By pressing "ok" the assignment "projects" are downloaded to your computer.
 
-The next video shows how to program and submit the assignments using TMC/NetBeans. The process is mostly the same in IntelliJ, except ,**important**,
+The next video shows how to program and submit the assignments using TMC/NetBeans. The process is mostly the same in IntelliJ, except, **important**,
 for the first time you open up an exercise, you need to set the JDK that you installed earlier. IntelliJ should ask you give it, but if not,
 you can set it from File / Project Structure at "Project SDK" part.
 

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -71,7 +71,7 @@ When IntelliJ opens for the first time, you get to a welcome screen. At the bott
 choose "Browse repositories" and type something like "TMC" to the search field. Install the plugin and restart IntelliJ.
 
 
-# Completing and submitting the programming assignments with Netbeans
+# Completing and submitting the programming assignments with Netbeans or IntelliJ
 
 If you're using **Netbeans** with TMC, the first time you start it, the below window should open. If it does not open, you can find it from the TMC / Settings. If you're
 using **IntelliJ**, you get to a Welcome screen, in which you can press the "Get started with TMC" button.

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -14,11 +14,13 @@ If you already have an account in TMC, you do not need a new one. Ensure that yo
 
 In the course we'll be using version 8.0 of the NetBeans Integrated Development Enviroinment and the TMC plugin to download and submit the programming assignments. NetBeans requires Java development kit (JDK) to be installed.
 
+As an alternative to Netbeans, you may also use Jetbrains's IntelliJ IDEA, which has a commercial Ultimate version, but also a completely free Community version (which is fine for this course).
+
 **NOTE:** If you have an old version of NetBeans on your computer, we recommend that you remove it before installing the new version. When the installation procedure asks  if the old setting should be imported, answer "no".
 
 **Does the installation of Java to your computer cause a security risk?** Not directly. The use of JDK and NetBeans do not cause any risk. The risks involved with Java are related to certain Web-pages that use Java-based components. Nothing we do in this course can cause any security risk to your computer. The installation of JDK also installs a Java plugin to your internet-brower. It might be wise to disable that plugin. For more information, see  <http://krebsonsecurity.com/how-to-unplug-java-from-the-browser/>.
 
-1. Installing JDK
+1. Installing JDK (the same whether you're using Netbeans or IntelliJ)
 
    If you already have JDK 7 or newer installed, go directly to step 2.
 
@@ -32,7 +34,9 @@ In the course we'll be using version 8.0 of the NetBeans Integrated Development 
 
    - In most **Linux** distibutions you get JDK directly from the packet management. In Debian based distributions (eg. in Ubuntu) it is enought to install the package *openjdk-7-jdk* which can be done in command line with the command `sudo apt-get install openjdk-7-jdk -y` or by using the Synaptic Package Manager. In the case that your distribution does not provide a suitable JDK, you can do the installation by extracting the .tar.gz-file found on the Oracle page.
 
-2. Installing NetBeans
+**Next**, choose one of 2a or 2b Depending on which programming environment you're using
+
+2a. Installing NetBeans
 
    **JDK must be installed before installing NetBeans.**
 
@@ -47,11 +51,34 @@ In the course we'll be using version 8.0 of the NetBeans Integrated Development 
       - The script can be executed only if it has been given right permissions eg. with command `chmod o+x tmc-netbeans_mooc_tmcbeans-linux.sh`.
       - In Ubuntu, for example, the execution permissions can be given using the File browser  by right clicking the script and selecting Properties / Permissions / Allow executing file as program. After doing this, the script can be executed by clicking it.
 
-# Completing and submitting the programming assignments
+2b. Installing IntelliJ IDEA
 
-When you start NetBeans with TMC for the first time, the below window should open. If it does not open, you can find it from the TMC / Settings in NetBeans menu bar.
+First, download IntelliJ IDEA Community version. Choose your operating system and in the address linked, press the
+Download button.
+
+   - [Windows](https://www.jetbrains.com/idea/download/#section=windows)
+      - The installation is done by opening the downloaded executable file
+   - [OS X (Mac)](https://www.jetbrains.com/idea/download/#section=linux)
+      - The installation is done the same way as any .dmg package. Move the IDEA app inside the downloaded package to your Applications folder
+   - [Linux](https://www.jetbrains.com/idea/download/#section=linux)
+      - The installation is done by executing the installation script by giving the command `./bin/idea.sh` in the directory where the file is located
+      - The script can be executed only if it has been given right permissions eg. with command `chmod +x bin/idea.sh`.
+      - In Ubuntu, for example, the execution permissions can be given using the File browser  by right clicking the script and selecting Properties / Permissions / Allow executing file as program. After doing this, the script can be executed by clicking it.
+
+Then, download the the TestMyCode plugin. 
+
+When IntelliJ opens for the first time, you get to a welcome screen. At the bottom, choose Configure / Plugins. At the bottom of the window that opens,
+choose "Browser repositores" and type something like "TMC" to the search field. Install the plugin and restart IntelliJ.
+
+
+# Completing and submitting the programming assignments with Netbeans
+
+If you're using **Netbeans** with TMC, the first time you start it, the below window should open. If it does not open, you can find it from the TMC / Settings. If you're
+using **IntelliJ**, you get to a Welcome screen, in which you can press the "Get started with TMC" button.
 
 ![tmc-settings]({{ "/img/programming/tmc-settings.png" | prepend: site.baseurl }})
+
+Now move on to the next phase
 
 Give the Username and Password that you gave during registration.
 
@@ -59,7 +86,9 @@ Press the button "refresh list" and select course from "Current course".
 
 By pressing "ok" the assignment "projects" are downloaded to your computer.
 
-The next video shows how to program and submit the assignments using TMC/NetBeans.
+The next video shows how to program and submit the assignments using TMC/NetBeans. The process is mostly the same in IntelliJ, except ,**important**,
+for the first time you open up an exercise, you need to set the JDK that you installed earlier. IntelliJ should ask you give it, but if not,
+you can set it from File / Project Structure at "Project SDK" part.
 
 <iframe width="560" height="315" src="//www.youtube.com/embed/ZFsg0Uh0UVE" frameborder="0" allowfullscreen></iframe>
 

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -65,7 +65,7 @@ Download button.
       - The script can be executed only if it has been given right permissions eg. with command `chmod +x bin/idea.sh`.
       - In Ubuntu, for example, the execution permissions can be given using the File browser  by right clicking the script and selecting Properties / Permissions / Allow executing file as program. After doing this, the script can be executed by clicking it.
 
-Then, download the the TestMyCode plugin:
+Then, download the TestMyCode plugin:
 
 When IntelliJ opens for the first time, you get to a welcome screen. At the bottom, choose Configure / Plugins. At the bottom of the window that opens,
 choose "Browse repositories" and type something like "TMC" to the search field. Install the plugin and restart IntelliJ.

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -57,11 +57,11 @@ First, download IntelliJ IDEA Community version. Choose your operating system an
 Download button.
 
    - [Windows](https://www.jetbrains.com/idea/download/#section=windows)
-      - The installation is done by opening the downloaded executable file
+      - The installation is done by opening the downloaded executable file.
    - [OS X (Mac)](https://www.jetbrains.com/idea/download/#section=linux)
-      - The installation is done the same way as any .dmg package. Move the IDEA app inside the downloaded package to your Applications folder
+      - The installation is done the same way as any .dmg package. Move the IDEA app inside the downloaded package to your Applications folder.
    - [Linux](https://www.jetbrains.com/idea/download/#section=linux)
-      - The installation is done by executing the installation script by giving the command `./bin/idea.sh` in the directory where the file is located
+      - The installation is done by executing the installation script by giving the command `./bin/idea.sh` in the directory where the file is located.
       - The script can be executed only if it has been given right permissions eg. with command `chmod +x bin/idea.sh`.
       - In Ubuntu, for example, the execution permissions can be given using the File browser  by right clicking the script and selecting Properties / Permissions / Allow executing file as program. After doing this, the script can be executed by clicking it.
 

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -85,7 +85,7 @@ Press the button "refresh list" and select course from "Current course".
 By pressing "ok" the assignment "projects" are downloaded to your computer.
 
 The next video shows how to program and submit the assignments using TMC/NetBeans. The process is mostly the same in IntelliJ, however, there's
-one **important** thing: For the first time you open up an exercise, you need to set the JDK that you installed earlier. IntelliJ should ask you give it, but if not,
+one **important** thing: For the first time you open up an exercise, you need to set the JDK that you installed earlier. IntelliJ should ask you to give it, but if not,
 you can set it from File / Project Structure at "Project SDK" part.
 
 <iframe width="560" height="315" src="//www.youtube.com/embed/ZFsg0Uh0UVE" frameborder="0" allowfullscreen></iframe>

--- a/courses/general/programming/how-to-get-started.md
+++ b/courses/general/programming/how-to-get-started.md
@@ -14,7 +14,7 @@ If you already have an account in TMC, you do not need a new one. Ensure that yo
 
 In the course we'll be using version 8.0 of the NetBeans Integrated Development Enviroinment and the TMC plugin to download and submit the programming assignments. NetBeans requires Java development kit (JDK) to be installed.
 
-As an alternative to Netbeans, you may also use Jetbrains's IntelliJ IDEA, which has a commercial Ultimate version, but also a completely free Community version (which is fine for this course).
+As an alternative to Netbeans, you may use Jetbrains's IntelliJ IDEA, which has a commercial Ultimate version, but also a completely free Community version (which is fine for this course).
 
 **NOTE:** If you have an old version of NetBeans on your computer, we recommend that you remove it before installing the new version. When the installation procedure asks  if the old setting should be imported, answer "no".
 
@@ -36,7 +36,7 @@ As an alternative to Netbeans, you may also use Jetbrains's IntelliJ IDEA, which
 
 **Next**, choose one of 2a or 2b Depending on which programming environment you're using
 
-2a. Installing NetBeans
+### 2a. Installing NetBeans
 
    **JDK must be installed before installing NetBeans.**
 
@@ -51,7 +51,7 @@ As an alternative to Netbeans, you may also use Jetbrains's IntelliJ IDEA, which
       - The script can be executed only if it has been given right permissions eg. with command `chmod o+x tmc-netbeans_mooc_tmcbeans-linux.sh`.
       - In Ubuntu, for example, the execution permissions can be given using the File browser  by right clicking the script and selecting Properties / Permissions / Allow executing file as program. After doing this, the script can be executed by clicking it.
 
-2b. Installing IntelliJ IDEA
+### 2b. Installing IntelliJ IDEA
 
 First, download IntelliJ IDEA Community version. Choose your operating system and in the address linked, press the
 Download button.


### PR DESCRIPTION
Instructions for TMC plugin for IntelliJ. Added a directory of its own for IntelliJ, in which there is:
- index file containing the installation instructions for IntelliJ
- tmc directory containing an index file that has the TMC plugin installation instructions
- java directory containing an index file that has installation instructions for JDK

Also, changed the "Tehtävien tekeminen ja palauttaminen" page a little to have some IntelliJ specific notes besides the Netbeans notes that were there.

Finally, changed the English "How to get started" page to also have notes about IntelliJ.